### PR TITLE
Ignore emacs lockfiles when watching src directory

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -25,6 +25,11 @@ module.exports = {
       }
     ]
   },
+  devServer: {
+    watchOptions: {
+      ignored: '**/.#*'
+    }
+  },
   plugins: [
     new CleanWebpackPlugin(["dist"], {
       root: path.resolve(__dirname, "../")


### PR DESCRIPTION
This fixes the issue I was having with hot reloading.

Emacs creates a `.#foo.js` file whenevener `foo.js` is edited, this
triggers a reload from webpack which immediately breaks. We can
specify that webpack ignores this pattern of filenames using the
devServer.watchOptions.ignored config variable.